### PR TITLE
specs a bit refactored & updated to support 1.9.3 as well as 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'rspec'
+gem 'ffi'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,22 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.1)
+    ffi (1.4.0)
+    ffi (1.4.0-java)
+    rspec (2.13.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
+    rspec-core (2.13.0)
+    rspec-expectations (2.13.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.13.0)
+
+PLATFORMS
+  java
+  ruby
+
+DEPENDENCIES
+  ffi
+  rspec

--- a/lib/phash/text.rb
+++ b/lib/phash/text.rb
@@ -75,8 +75,8 @@ module Phash
           matched_b[index_b + i] = true
         end
       end
-      coverage_a = matched_a.nitems / hash_a.length.to_f
-      coverage_b = matched_b.nitems / hash_b.length.to_f
+      coverage_a = matched_a.compact.length / hash_a.length.to_f
+      coverage_b = matched_b.compact.length / hash_b.length.to_f
       (coverage_a + coverage_b) * 0.5
     end
   end

--- a/spec/phash_spec.rb
+++ b/spec/phash_spec.rb
@@ -1,12 +1,12 @@
 require File.dirname(__FILE__) + '/spec_helper.rb'
 
 describe :Phash do
-  data_dir = FSPath(__FILE__).dirname / 'data'
+  include SpecHelpers
 
   shared_examples :similarity do
     it "should return valid similarities" do
       collection.combination(2) do |a, b|
-        if a.path.main_name == b.path.main_name
+        if main_name(a.path) == main_name(b.path)
           (a % b).should > 0.8
         else
           (a % b).should <= 0.5
@@ -22,22 +22,22 @@ describe :Phash do
   end
 
   describe :Audio do
-    let(:collection){ Phash::Audio.for_paths(data_dir.glob('*.mp3')) }
+    let(:collection){ Phash::Audio.for_paths filenames('*.mp3') }
     include_examples :similarity
   end
 
   describe :Image do
-    let(:collection){ Phash::Image.for_paths(data_dir.glob('**/*.{jpg,png}')) }
+    let(:collection){ Phash::Image.for_paths filenames('**/*.{jpg,png}') }
     include_examples :similarity
   end
 
   describe :Text do
-    let(:collection){ Phash::Text.for_paths(data_dir.glob('*.txt')) }
+    let(:collection){ Phash::Text.for_paths filenames('*.txt') }
     include_examples :similarity
   end
 
   describe :Video do
-    let(:collection){ Phash::Video.for_paths(data_dir.glob('*.mp4')) }
+    let(:collection){ Phash::Video.for_paths filenames('*.mp4') }
     include_examples :similarity
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,14 @@
 $:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
-require 'rspec'
-require 'fspath'
+Bundler.require
 require 'phash'
 
-class FSPath
-  def main_name
-    basename.to_s.split('-', 2).first
+module SpecHelpers
+  def filenames(pattern)
+    data_dir = File.join File.dirname(__FILE__), 'data'
+    Dir.glob(File.join data_dir, pattern)
+  end
+
+  def main_name(path)
+    File.basename(path).split('-', 2).first
   end
 end


### PR DESCRIPTION
specs were failing for me on 1.9.3 because of FSPath and nitems() usage. Have refactored it not to use the 2 dependencies.

Added Gemfile so we can just 'bundle' to install dependencies.

All but audio tests are passing on 1.9.3 and 1.8.7.

Audio tests are throwing: function ph_readaudio not found [libpHash.so] but I suspect my installation of pHash being not complete (stock Ubuntu 12.10 universe).

On JRuby, also text similarity tests are failing (undefined method 'free' for FFI::Pointer) but I intend to fix it another time.
