### PR TITLE
Fixed pHash-0.9.6 compatibility with Latest ffmpeg 2.3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,6 +10,8 @@ You can specify path to pHash library explicitly using environment variable like
 
 Audio hash functions needs to be compiled with C linkage, so if you get `FFI::NotFoundError` check names of methods in `libpHash`. Tiny patch for pHash 0.9.4 is in `audiophash.diff`.
 
+Video hash needs [patched pHash 0.9.6](https://github.com/hszcg/pHash-0.9.6) to fit into latest ffmpeg changes, This patch resolved the issue about [Segmentation Fault error when trying to compare two videos with pHash library and its ruby bindings](http://stackoverflow.com/q/23414036/96823), please checkout the code and build from source if you want to use Video hash.
+
 ## Dependencies
 
 * [pHash](http://www.phash.org/download/)


### PR DESCRIPTION
See my patch for pHash-0.9.6 on https://github.com/hszcg/pHash-0.9.6/commit/85218a6443f93d0bbafc4d36c8c6ab9673d0d2c5

This patch resolved the issue about **Segmentation Fault error when trying to compare two videos with pHash library and its ruby bindings** , see http://stackoverflow.com/questions/23414036/segmentation-fault-error-when-trying-to-compare-two-videos-with-phash-library-an
