### PR TITLE
Gemspec: Drop EOL'd rubyforge_project directive

### DIFF
--- a/pHash.gemspec
+++ b/pHash.gemspec
@@ -8,8 +8,6 @@ Gem::Specification.new do |s|
   s.authors     = ['Ivan Kuchin']
   s.license     = 'GPLv3'
 
-  s.rubyforge_project = s.name
-
   s.metadata = {
     'bug_tracker_uri'   => "https://github.com/toy/#{s.name}/issues",
     'documentation_uri' => "https://www.rubydoc.info/gems/#{s.name}/#{s.version}",


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.